### PR TITLE
feat(server): only apply necessary properties

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -48,7 +48,18 @@ lib.callback.register('sensei_garages:storeVehicle', function(source, netId, gar
 
     if not hasPermission(player, vehicle, garage) then return false, 'no_permission' end
 
-    vehicle.setProperties(vehicleProperties, false)
+    local properties = vehicle.getProperties()
+    properties.bodyHealth = vehicleProperties.bodyHealth
+    properties.engineHealth = vehicleProperties.engineHealth
+    properties.tankHealth = vehicleProperties.tankHealth
+    properties.fuelLevel = vehicleProperties.fuelLevel
+    properties.oilLevel = vehicleProperties.oilLevel
+    properties.dirtLevel = vehicleProperties.dirtLevel
+    properties.windows = vehicleProperties.windows
+    properties.doors = vehicleProperties.doors
+    properties.tyres = vehicleProperties.tyres
+
+    vehicle.setProperties(properties, false)
     vehicle.setStored(garageId, true)
     return true
 end)


### PR DESCRIPTION
To prevent cheaters from applying anything they would like, we only apply the necessary properties for damage, dirt and fuel saving.